### PR TITLE
Issue 118

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,8 @@
 import { Routes, Route, useNavigate, Navigate } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil'
+import { useRecoilValue } from 'recoil'
 import { DarkModeAtom } from './recoil/AtomDarkModeState'
 import styled from 'styled-components'
 
-import { IsLogin, UserAtom } from './recoil/AtomUserState';
 import DefaultTheme from './style/theme/DefaultTheme'
 import DarkTheme from './style/theme/DarkTheme'
 
@@ -30,32 +29,15 @@ import WebHeader from './components/pcVersion/WebHeader';
 import WebNavBar from './components/pcVersion/WebNavBar';
 import WebFollowersRecommend from './components/pcVersion/WebFollowersRecommend';
 import WebBillboard from './components/pcVersion/WebBillboard';
-import Alert from './components/common/Alert';
-import useAlertControl from './hooks/useAlertControl';
-
 
 function App() {
 
   const darkMode = useRecoilValue(DarkModeAtom);
-  const { openAlert, AlertComponent } = useAlertControl();
-
-  const setUserValue = useSetRecoilState(UserAtom);
-  const setIsLogin = useSetRecoilState(IsLogin);
-  const navigate = useNavigate();
-
-  const handleLogout = (event) =>{
-    if (event.target.textContent === '로그아웃') {
-      setUserValue({})
-      setIsLogin(false)
-      sessionStorage.removeItem('user')
-      navigate('/splash');
-    } 
-  }
-
+  
   return (
     <PcStyle>
       <WebHeaderStyle>
-        <WebHeader handleFunc={openAlert}/>
+        <WebHeader/>
       </WebHeaderStyle>
       <MainStyle>
         <WebNavBarStyle>
@@ -102,9 +84,6 @@ function App() {
             </Routes>
             <NavBar />
             {darkMode ? <DarkTheme /> : <DefaultTheme />}
-          <AlertComponent>
-            <Alert alertMsg={'로그아웃 하시겠습니까?'} choice={['취소', '로그아웃']} handleFunc={handleLogout} />
-          </AlertComponent>
           </BaseSizeStyle>
         </WrapperStyle>
 
@@ -133,14 +112,9 @@ const WebHeaderStyle = styled.div`
   }
 `;
 
-const MainStyle = styled.div`
+const MainStyle =  styled.div`
   display: flex;
   justify-content: center;   
-  margin-left : 172px; // 팔로우 추천, 네비게이션 바의 너비 차이 만큼 오른쪽으로 땡기기
-
-  @media (max-width: 768px) {
-    margin-left : 0;
-  }
 `;
 
 const WebNavBarStyle = styled.div`
@@ -155,7 +129,7 @@ const WebFollowersRecommendStyle = styled.div`
   margin-top: 4%;
   display: none;
   
-  @media (min-width: 1300px) {
+  @media (min-width: 1500px) {
     display: block;
   }
 `;
@@ -163,17 +137,17 @@ const WebFollowersRecommendStyle = styled.div`
 const WrapperStyle = styled.div`
   display: flex;
   justify-content: center;
-
-  @media (min-width: 768px) {
-    margin-top: 26px;
-  }
 `;
 
 const BaseSizeStyle = styled.div`
+margin: 0;
+overflow: hidden;
+width: var(--basic-width);
+height: var(--basic-height);
+background-color: var(--background-color);
+
+@media (min-width: 1500px) {
   margin: 0 110px; // 팔로우 추천, 네비게이션 바 간격 고정되도록 가운데에 마진값 주기
-  overflow: hidden;
-  width: var(--basic-width);
-  height: var(--basic-height);
-  background-color: var(--background-color);
+}
 `;
 

--- a/src/assets/img/sun.svg
+++ b/src/assets/img/sun.svg
@@ -1,11 +1,11 @@
 <svg width="40" height="39" viewBox="0 0 40 39" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M30 19.5C30 24.7467 25.7467 29 20.5 29C15.2533 29 11 24.7467 11 19.5C11 14.2533 15.2533 10 20.5 10C25.7467 10 30 14.2533 30 19.5Z" fill="#212529"/>
-<path d="M20 2V6" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
-<path d="M20 33V37" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
-<path d="M34 21L38 21" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
-<path d="M2 21L6 21" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
-<path d="M7 32.8284L9.82843 29.9999" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
-<path d="M31.3535 11.4485L34.1116 8.55144" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
-<path d="M33.8281 32.8284L30.9997 29.9999" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
-<path d="M9.1626 10.3973L6.30076 7.60273" stroke="#212529" stroke-width="3" stroke-linecap="round"/>
+<path d="M30 19.5C30 24.7467 25.7467 29 20.5 29C15.2533 29 11 24.7467 11 19.5C11 14.2533 15.2533 10 20.5 10C25.7467 10 30 14.2533 30 19.5Z" fill="#ED7B7B"/>
+<path d="M20 2V6" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
+<path d="M20 33V37" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
+<path d="M34 21L38 21" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
+<path d="M2 21L6 21" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
+<path d="M7 32.8284L9.82843 29.9999" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
+<path d="M31.3535 11.4485L34.1116 8.55144" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
+<path d="M33.8281 32.8284L30.9997 29.9999" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
+<path d="M9.1626 10.3973L6.30076 7.60273" stroke="#ED7B7B" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/components/common/Post.jsx
+++ b/src/components/common/Post.jsx
@@ -159,17 +159,19 @@ to {
 `;
 
 const PostStyle = styled.article`
+  padding-top: 0px;
   position: relative;
   margin-bottom: 20px;
   width: 358px;
-
+  
   @media (min-width: 768px) {
+    padding-top: 26px;
     width: 500px;
   }
 
   .postMoreButton {
     position: absolute;
-    top: 0px;
+    top: 26px;
     right: 0px;
     width: 18px;
     height: 18px;

--- a/src/components/header/SearchHeader.jsx
+++ b/src/components/header/SearchHeader.jsx
@@ -53,7 +53,10 @@ const SearchHeaderStyle = styled.div`
   @media (min-width: 768px) {
     box-shadow: none;
     #searchId {
+      width: var(--basic-width);
       margin: auto;
+      margin-bottom: -5px;
+      border-radius: 10px;
     }
   }
   `;

--- a/src/components/header/UploadHeader.jsx
+++ b/src/components/header/UploadHeader.jsx
@@ -36,6 +36,7 @@ const BasicHeaderStyle = styled.div`
   background-color: var(--header-color);
 
   @media (min-width: 768px) {
+    background-color: var(--background-color);
     justify-content: right;
     box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
 

--- a/src/components/pcVersion/WebBillboard.jsx
+++ b/src/components/pcVersion/WebBillboard.jsx
@@ -4,13 +4,22 @@ import styled from "styled-components"
 export default function WebBillboard() {
 
   const location = useLocation();
+  const hideBillboardPaths = [
+    '/splash',
+    '/login',
+    '/signup',
+    '/feed',
+    '/recommendfeed',
+    '/profile'
+  ]
 
+  const hideBillboard = hideBillboardPaths.includes(location.pathname);
   return (
     <>
-    {location.pathname !== '/feed' && location.pathname !== '/recommendfeed' && location.pathname !== '/profile' && 
-    <AreaOccupy>
-    </AreaOccupy>
-    }
+      {!hideBillboard &&
+        <AreaOccupy>
+        </AreaOccupy>
+      }
     </>
   )
 }

--- a/src/components/pcVersion/WebHeader.jsx
+++ b/src/components/pcVersion/WebHeader.jsx
@@ -1,35 +1,63 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
-
-import { ReactComponent as Tadak} from '../../assets/img/tadak.svg';
-import { ReactComponent as WebLogo} from '../../assets/img/weblogo.svg';
-import { ReactComponent as IconLogout}  from '../../assets/img/icon-logout.svg';
+import { useSetRecoilState } from 'recoil'
+import { IsLogin, UserAtom } from '../../recoil/AtomUserState';
+import { ReactComponent as Tadak } from '../../assets/img/tadak.svg';
+import { ReactComponent as WebLogo } from '../../assets/img/weblogo.svg';
+import { ReactComponent as IconLogout } from '../../assets/img/icon-logout.svg';
 import DarkModeBtn from '../DarkModeBtn';
 
-export default function WebHeader({handleFunc}) {
+export default function WebHeader() {
+
+  const setUserValue = useSetRecoilState(UserAtom);
+  const setIsLogin = useSetRecoilState(IsLogin);
+  const navigate = useNavigate();
+
+  const location = useLocation();
+  const hideHeaderPaths = [
+    '/splash',
+    '/login',
+    '/signup'
+  ]
+
+  const hideHeader = hideHeaderPaths.includes(location.pathname);
+
+  const handleLogout = (event) =>{
+      setUserValue({})
+      setIsLogin(false)
+      sessionStorage.removeItem('user')
+      navigate('/splash');
+  }
+
   return (
-    <WebHeaderStyle>
-        <WebLogoStyle>
+    <>
+      {!hideHeader &&
+        <WebHeaderStyle>
+          <WebLogoStyle>
             <WebLogo></WebLogo>
             <TadakStyle>
-              <Tadak style={{ width: '104px', height: '25.58 px' }}/>
+              <Tadak style={{ width: '104px', height: '25.58 px' }} />
             </TadakStyle>
-        </WebLogoStyle>
-        <BtnStyle>
-          <DarkModeBtn style={{ width: '44px', height: '44px'}}/>
-          <IconLogout onClick={handleFunc} style={{ width: '30px', height: '30px', cursor: 'pointer', margin: '25px 0'}}/>
-        </BtnStyle>
-    </WebHeaderStyle>
+          </WebLogoStyle>
+          <BtnStyle>
+            <DarkModeBtn style={{ width: '44px', height: '44px' }} />
+            <IconLogout onClick={handleLogout} style={{ width: '23px', height: '23px', cursor: 'pointer'}} />
+          </BtnStyle>
+        </WebHeaderStyle>
+      }
+    </>
   )
 }
 
 const WebHeaderStyle = styled.div`
+    position: relative;
     width: 100vw;
     height: 80px;
-    background-color: #B9D6A3;
+    background-color: var(--basic-color-1);
     display: flex;
     justify-content: space-between;
+    z-index: 1000;
 `;
 
 const WebLogoStyle = styled.div`
@@ -45,7 +73,8 @@ top: -10px;
 `;
 
 const BtnStyle = styled.div`
- display: flex;
- gap: 28px;
- margin-right: 10%;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  margin-right: 10%;
 `;

--- a/src/components/pcVersion/WebNavBar.jsx
+++ b/src/components/pcVersion/WebNavBar.jsx
@@ -12,9 +12,15 @@ import { ReactComponent as IconSearch } from '../../assets/img/icon-web-search.s
 
 export default function WebNavBar() {
 
-  const location = useLocation();
-  const accountname = sessionStorage.getItem('user') === null?'':JSON.parse(sessionStorage.getItem('user')).UserAtom.accountname
 
+  const location = useLocation();
+  const accountname = sessionStorage.getItem('user') === null ? '' : JSON.parse(sessionStorage.getItem('user')).UserAtom.accountname
+  const hideNavbarPaths = [
+    '/splash',
+    '/login',
+    '/signup'
+  ]
+  const hideNavbar = hideNavbarPaths.includes(location.pathname);
   const navItems = [
     { to: '/feed', component: IconHome, label: '홈' },
     { to: '/recommendfeed', component: IconHeart, label: '추천게시글' },
@@ -39,6 +45,9 @@ export default function WebNavBar() {
   }, [location.pathname, selectedIcon]);
 
   return (
+    <>
+    {
+    !hideNavbar &&
     <WebNavBarStyle>
       <NavBarStyle>
         {navItems.map((item) => (
@@ -60,6 +69,8 @@ export default function WebNavBar() {
         ))}
       </NavBarStyle>
     </WebNavBarStyle>
+    }    
+    </>
   )
 }
 
@@ -76,6 +87,10 @@ const SettingStyle = styled.div`
 const WebNavBarStyle = styled.div`
   width: 220px;
   height: 594px;
+  margin: 0 100px 0 0;
+  @media (min-width: 1500px) {
+    margin: 0 0 0 172px; // 팔로우 추천, 네비게이션 바의 너비 차이 만큼 오른쪽으로 땡기기
+  }
 `;
 
 const NavBarStyle = styled.div`

--- a/src/pages/SplashPage.jsx
+++ b/src/pages/SplashPage.jsx
@@ -20,14 +20,16 @@ export default function SplashPage() {
   return (
     <>
     <SplashPageStyle>
+      <SplashCharacterContainer>
         <TitleStyle1></TitleStyle1>
         <TitleStyle2></TitleStyle2>
         <FireworkRStyle></FireworkRStyle>
         <FireworkLStyle></FireworkLStyle>
         <FireStyle></FireStyle>
         <WoodFireStyle></WoodFireStyle>
-        <section>
         <SubTitleStyle></SubTitleStyle>
+      </SplashCharacterContainer>
+        <section>
         <LoginModalStyle>
           <ul>
             <li>
@@ -61,6 +63,10 @@ export default function SplashPage() {
     </>
   )
 }
+
+const SplashCharacterContainer = styled.div`
+  text-align: center; 
+`;
 
 const firework1 = keyframes`
   0% {
@@ -142,7 +148,7 @@ const FireStyle = styled(Fire)`
   margin: 0 auto;
   position: relative;
   top: 80px;
-  left: 60px;
+  left: 0px;
   z-index: 100;
   animation: ${firework1} 2s infinite;
 `  
@@ -170,12 +176,12 @@ const WoodFireStyle = styled(WoodFire)`
 
 const SubTitleStyle = styled(SubTitle)`
   position: relative;
-  margin: 0 88px;
+  text-align: center;
   top: -20px 
 `
 
 const LoginModalStyle = styled.article`
-width: 390px;
+width: var(--basic-width);
 height: 100vh;
 border-radius: 20px;
 background-color: #ffffff;

--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -21,7 +21,6 @@ export const GlobalStyle = createGlobalStyle`
     --screen-height : calc(var(--basic-height) - 48px);
     --screen-nav-height : calc(var(--basic-height) - (60px + 48px));
 
-
     --font--size-lg: 16px;                  
     --font--size-md: 14px;                  
     --font--size-sm: 12px;    
@@ -33,8 +32,8 @@ export const GlobalStyle = createGlobalStyle`
     @media (min-width: 768px) {
       --basic-width : 500px;
       /* --screen-nav-height : 100vh; */
-      --screen-nav-height : calc(var(--basic-height) - (106px));
-      --screen-height : calc(var(--basic-height) - (106px));
+      --screen-nav-height : calc(var(--basic-height) - (80px));
+      --screen-height : calc(var(--basic-height) - (80px));
       
       --font--size-lg: 18px;                  
       --font--size-md: 16px;


### PR DESCRIPTION
- splash, 로그인, 회원가입 화면에서 Header, Navigation Bar 감추기
- WebHeader에 다크모드버튼, 로그아웃버튼 디자인 수정
- PC 버전에서 그대로사용되는 기존 header 배경색상 수정
- 게시글 페이지에서 맨위에 여백주기
- SplashPage에 뜨는 모달 width값 수정
- Splash 캐릭터 위치 재조정
- 창 너비에 따라 네비게이션과 메인스크린 보기좋게 정렬
- 모달로인해 가려지는 WebHeader에 z-index와 postion주기